### PR TITLE
fix:账号登录记住我不起作用

### DIFF
--- a/src/views/login/components/account/index.vue
+++ b/src/views/login/components/account/index.vue
@@ -122,14 +122,14 @@ const handleLogin = async () => {
     })
     tabsStore.reset()
     const { redirect, ...othersQuery } = router.currentRoute.value.query
+    const { rememberMe } = loginConfig.value
+    loginConfig.value.username = rememberMe ? form.username : ''
     await router.push({
       path: (redirect as string) || '/',
       query: {
         ...othersQuery,
       },
     })
-    const { rememberMe } = loginConfig.value
-    loginConfig.value.username = rememberMe ? form.username : ''
     Message.success('欢迎使用')
   } catch (error) {
     console.error(error)


### PR DESCRIPTION

## PR 类型


- [ ] 新 feature
- [x] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

修复账号登录页面的记住我，勾选上，本地缓存不起作用。

## 解决方案

原先修改缓存的代码在await router.push()后面，页面跳转后不起作用，把要修改缓存代码移到页面跳转之前

## PR 测试


## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|     |           |                |


## 其他信息


## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [ ] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支