### PR TITLE
feat: 添加文件列表全选功能

### DIFF
--- a/src/views/system/file/main/FileMain/FileList.vue
+++ b/src/views/system/file/main/FileMain/FileList.vue
@@ -10,7 +10,7 @@
       :selected-keys="selectedFileIds"
       column-resizable
       @select="select"
-      @selectAll="selectAll"
+      @select-all="selectAll"
     >
       <template #columns>
         <a-table-column title="名称">
@@ -89,7 +89,7 @@ const emit = defineEmits<{
   (e: 'click', record: FileItem): void
   (e: 'dblclick', record: FileItem): void
   (e: 'select', record: FileItem): void
-  (e: 'selectAll', checked: boolean): void
+  (e: 'select-all', checked: boolean): void
   (e: 'right-menu-click', mode: string, item: FileItem): void
 }>()
 
@@ -127,7 +127,7 @@ const select: TableInstance['onSelect'] = (_rowKeys, _rowKey, record: unknown) =
 
 // 全选 - 点击表头全选复选框
 const selectAll: TableInstance['onSelectAll'] = (checked: boolean) => {
-  emit('selectAll', checked)
+  emit('select-all', checked)
 }
 
 // 单击事件

--- a/src/views/system/file/main/FileMain/FileList.vue
+++ b/src/views/system/file/main/FileMain/FileList.vue
@@ -10,6 +10,7 @@
       :selected-keys="selectedFileIds"
       column-resizable
       @select="select"
+      @selectAll="selectAll"
     >
       <template #columns>
         <a-table-column title="名称">
@@ -88,6 +89,7 @@ const emit = defineEmits<{
   (e: 'click', record: FileItem): void
   (e: 'dblclick', record: FileItem): void
   (e: 'select', record: FileItem): void
+  (e: 'selectAll', checked: boolean): void
   (e: 'right-menu-click', mode: string, item: FileItem): void
 }>()
 
@@ -115,14 +117,22 @@ const calculateDirSize = async (record: FileItem) => {
   }
 }
 
-// 多选
-const select: TableInstance['onSelect'] = (rowKeys, rowKey, record) => {
-  emit('select', record as unknown as FileItem)
+// 多选 - 点击单个复选框
+const select: TableInstance['onSelect'] = (_rowKeys, _rowKey, record: unknown) => {
+  // 只有点击具体行的复选框时才触发（点击表头全选时 record 为 undefined）
+  if (record) {
+    emit('select', record as FileItem)
+  }
+}
+
+// 全选 - 点击表头全选复选框
+const selectAll: TableInstance['onSelectAll'] = (checked: boolean) => {
+  emit('selectAll', checked)
 }
 
 // 单击事件
-const handleClick = (record) => {
-  emit('click', record as unknown as FileItem)
+const handleClick = (record: unknown) => {
+  emit('click', record as FileItem)
 }
 
 // 双击事件

--- a/src/views/system/file/main/FileMain/index.vue
+++ b/src/views/system/file/main/FileMain/index.vue
@@ -283,7 +283,7 @@ const handleSelectAll = (checked: boolean) => {
     })
   } else {
     // 取消全选：移除当前页所有已选中的文件
-    const currentPageIds = new Set(fileList.value.map(item => item.id))
+    const currentPageIds = new Set(fileList.value.map((item) => item.id))
     selectedFileList.value = selectedFileList.value.filter(
       (item) => !currentPageIds.has(item.id)
     )

--- a/src/views/system/file/main/FileMain/index.vue
+++ b/src/views/system/file/main/FileMain/index.vue
@@ -109,6 +109,7 @@
       <FileList
         v-show="fileList.length && mode === 'list'" :data="fileList" :is-batch-mode="isBatchMode"
         :selected-file-ids="selectedFileIds" @click="handleClickFile" @select="handleSelectFile"
+        @selectAll="handleSelectAll"
         @right-menu-click="handleRightMenuClick" @dblclick="handleDblclickFile"
       ></FileList>
 
@@ -154,7 +155,7 @@ const FilePreview = defineAsyncComponent(() => import('@/components/FilePreview/
 
 const FileList = defineAsyncComponent(() => import('./FileList.vue'))
 const route = useRoute()
-const { mode, selectedFileIds, toggleMode, addSelectedFileItem } = useFileManage()
+const { mode, selectedFileList, selectedFileIds, toggleMode, addSelectedFileItem } = useFileManage()
 const { width } = useWindowSize()
 const queryForm = reactive<FileQuery>({
   originalName: undefined,
@@ -269,6 +270,24 @@ const handleRightMenuClick = async (mode: string, fileInfo: FileItem) => {
 // 勾选文件
 const handleSelectFile = (item: FileItem) => {
   addSelectedFileItem(item)
+}
+
+// 全选/取消全选
+const handleSelectAll = (checked: boolean) => {
+  if (checked) {
+    // 全选：将当前页所有未选中的文件添加到选中列表
+    fileList.value.forEach((item) => {
+      if (!selectedFileIds.value.includes(item.id)) {
+        selectedFileList.value.push(item)
+      }
+    })
+  } else {
+    // 取消全选：移除当前页所有已选中的文件
+    const currentPageIds = new Set(fileList.value.map(item => item.id))
+    selectedFileList.value = selectedFileList.value.filter(
+      (item) => !currentPageIds.has(item.id)
+    )
+  }
 }
 
 // 批量删除

--- a/src/views/system/file/main/FileMain/index.vue
+++ b/src/views/system/file/main/FileMain/index.vue
@@ -109,7 +109,7 @@
       <FileList
         v-show="fileList.length && mode === 'list'" :data="fileList" :is-batch-mode="isBatchMode"
         :selected-file-ids="selectedFileIds" @click="handleClickFile" @select="handleSelectFile"
-        @selectAll="handleSelectAll"
+        @select-all="handleSelectAll"
         @right-menu-click="handleRightMenuClick" @dblclick="handleDblclickFile"
       ></FileList>
 


### PR DESCRIPTION
列表模式的全选功能点击没有反应，添加文件列表全选功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 文件列表支持表头一键全选/取消，能对当前页面文件批量选中或取消。
  * 选择列表状态在管理逻辑中暴露并被页面消费，便于显示与后续操作。
* **改进**
  * 优化多选交互：区分表头复选与行复选，行级点击仅在对应项被勾选时触发选择事件，避免重复或误触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->